### PR TITLE
升级依赖版本解决依赖冲突问题，区分渲染和静音模式变量，增加linux支持

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -62,6 +62,19 @@ pip install setuptools==65.5.0 pip==21
 pip install -r requirements.txt
 ```
 
+Linux:
+```bash 
+# 使用 GPU 训练需要手动安装完整版 PyTorch
+conda install pytorch=2.0.0 torchvision pytorch-cuda=11.8 -c pytorch -c nvidia
+
+# 运行程序脚本测试 PyTorch 是否能成功调用 GPU
+python .\utils\check_gpu_status.py
+
+# 安装外部代码库
+pip install setuptools==65.5.0 pip==23.1.2
+pip install -r requirements.txt
+```
+
 ### 运行测试
 
 项目 `main/` 文件夹下包含经典游戏《贪吃蛇》的程序脚本，基于 [Pygame](https://www.pygame.org/news) 代码库，可以直接运行以下指令进行游戏：

--- a/main/snake_game.py
+++ b/main/snake_game.py
@@ -32,8 +32,10 @@ class SnakeGame:
             self.sound_game_over = mixer.Sound("sound/game_over.wav")
             self.sound_victory = mixer.Sound("sound/victory.wav")
         else:
-            self.screen = None
-            self.font = None
+            pygame.init()
+            pygame.display.set_caption("Snake Game")
+            self.screen = pygame.display.set_mode((self.display_width, self.display_height))
+            self.font = pygame.font.Font(None, 36)
 
         self.snake = None
         self.non_snake = None

--- a/main/test_cnn.py
+++ b/main/test_cnn.py
@@ -14,6 +14,7 @@ else:
 NUM_EPISODE = 10
 
 RENDER = True
+SILENT_MODE = True
 FRAME_DELAY = 0.05 # 0.01 fast, 0.05 slow
 ROUND_DELAY = 5
 
@@ -21,7 +22,7 @@ seed = random.randint(0, 1e9)
 print(f"Using seed = {seed} for testing.")
 
 if RENDER:
-    env = SnakeEnv(seed=seed, limit_step=False, silent_mode=False)
+    env = SnakeEnv(seed=seed, limit_step=False, silent_mode=SILENT_MODE)
 else:
     env = SnakeEnv(seed=seed, limit_step=False, silent_mode=True)
 

--- a/main/test_mlp.py
+++ b/main/test_mlp.py
@@ -10,15 +10,15 @@ MODEL_PATH = r"trained_models_mlp/ppo_snake_final"
 NUM_EPISODE = 10
 
 RENDER = True
+SILENT_MODE = True
 FRAME_DELAY = 0.05 # 0.01 fast, 0.05 slow
 ROUND_DELAY = 5
 
 seed = random.randint(0, 1e9)
 print(f"Using seed = {seed} for testing.")
 
-
 if RENDER:
-    env = SnakeEnv(seed=seed, limit_step=False, silent_mode=False)
+    env = SnakeEnv(seed=seed, limit_step=False, silent_mode=SILENT_MODE)
 else:
     env = SnakeEnv(seed=seed, limit_step=False, silent_mode=True)
 

--- a/main/test_mlp.py
+++ b/main/test_mlp.py
@@ -10,15 +10,15 @@ MODEL_PATH = r"trained_models_mlp/ppo_snake_final"
 NUM_EPISODE = 10
 
 RENDER = True
+SILENT_MODE = False
 FRAME_DELAY = 0.05 # 0.01 fast, 0.05 slow
 ROUND_DELAY = 5
 
 seed = random.randint(0, 1e9)
 print(f"Using seed = {seed} for testing.")
 
-
 if RENDER:
-    env = SnakeEnv(seed=seed, limit_step=False, silent_mode=False)
+    env = SnakeEnv(seed=seed, limit_step=False, silent_mode=SILENT_MODE)
 else:
     env = SnakeEnv(seed=seed, limit_step=False, silent_mode=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gym==0.21.0
-stable-baselines3==1.8.0
-sb3-contrib==1.8.0
+gym==0.26.2
+stable-baselines3==2.0.0
+sb3-contrib==2.0.0
 pygame==2.3.0


### PR DESCRIPTION
若静音模式设置为false,在我的arch linux无法正常运行，表现在 mixer.init() 失败。
具体报错为：
pygame.error: dsp: No such audio device

上述报错暂时没有找到解决方案，故我在测试项目过程中单独设置静音模式，项目运行正常。
已经验证，在我修改的版本下，linux上可正常运行程序。